### PR TITLE
Resolve small sidebar padding issue

### DIFF
--- a/src/layout/PageHeader.tsx
+++ b/src/layout/PageHeader.tsx
@@ -89,7 +89,7 @@ export function PageHeaderFirstSection({
 
   return (
     <div
-      className={` gap-4 items-center flex-shrink-0 ${
+      className={`pl-1 gap-4 items-center flex-shrink-0 ${
         hidden ? "hidden" : "flex"
       }`}
     >

--- a/src/layout/SideBar.tsx
+++ b/src/layout/SideBar.tsx
@@ -199,7 +199,7 @@ function SmallSideBarItem({ Icon, title, url }: SmallSideBarProps) {
       )}
     >
       <Icon className="w-6 h-6" />
-      <div className="text-sm">{title}</div>
+      <div className="text-[.6rem]">{title}</div>
     </a>
   );
 }


### PR DESCRIPTION
Resolved small sidebar  issue by editing the font size of small sidebar icon title text and adding padding left in order to be aligned with the large sidebar